### PR TITLE
Fix test badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](../../workflows/gds/badge.svg) ![](../../workflows/docs/badge.svg) ![](../../workflows/wokwi_test/badge.svg)
+![](../../workflows/gds/badge.svg) ![](../../workflows/docs/badge.svg) ![](../../workflows/test/badge.svg)
 
 # What is Tiny Tapeout?
 


### PR DESCRIPTION
The test badge in the README was not appearing because of the `.yaml` being added.